### PR TITLE
Replacement of pycrypto by pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'ecdsa',
         'pylibscrypt',
         'scrypt',
-        'pycrypto',
+        'pycryptodome',
         'urllib3>=1.21.1',
         'certifi',
         'ujson',

--- a/steembase/bip38.py
+++ b/steembase/bip38.py
@@ -8,9 +8,12 @@ from .base58 import Base58, base58decode
 log = logging.getLogger(__name__)
 
 try:
-    from Crypto.Cipher import AES
+    from Cryptodome.Cipher import AES
 except ImportError:
-    raise ImportError("Missing dependency: pycrypto")
+    try:
+        from Crypto.Cipher import AES
+    except ImportError:
+        raise ImportError("Missing dependency: pyCryptodome")
 
 SCRYPT_MODULE = None
 if not SCRYPT_MODULE:


### PR DESCRIPTION
The old and un-maintained PyCrypto is replaced by the activly developed pycryptodome (https://github.com/Legrandin/pycryptodome). The last update for pyCrypto is 4 years old and pycryptodome offers an almost drop-in replacement for the old PyCrypto library!

I added compatibilty for pycryptodome and pycryptodomex. The lather, can be install parallel to pycryto and has Cryptodome namespace.