### PR TITLE
Improve HTTP Client

### DIFF
--- a/steem/cli.py
+++ b/steem/cli.py
@@ -24,7 +24,6 @@ availableConfigurationKeys = [
     "default_account",
     "default_vote_weight",
     "nodes",
-    "round_robin",
 ]
 
 

--- a/steem/steemd.py
+++ b/steem/steemd.py
@@ -51,7 +51,6 @@ class Steemd(HttpClient):
     def __init__(self, nodes=None, **kwargs):
         if not nodes:
             nodes = get_config_node_list() or ['https://api.steemit.com']
-        kwargs['round_robin'] = bool(configStorage.get('round_robin', None))
         
         super(Steemd, self).__init__(nodes, **kwargs)
 

--- a/steembase/http_client.py
+++ b/steembase/http_client.py
@@ -55,7 +55,6 @@ class HttpClient(object):
         self.return_with_args = kwargs.get('return_with_args', False)
         self.re_raise = kwargs.get('re_raise', True)
         self.max_workers = kwargs.get('max_workers', None)
-        self.round_robin = kwargs.get('round_robin', False)
 
         num_pools = kwargs.get('num_pools', 10)
         maxsize = kwargs.get('maxsize', 100)
@@ -146,10 +145,6 @@ class HttpClient(object):
             node fail-over, unless we are broadcasting a transaction.
             In latter case, the exception is **re-raised**.
         """
-        # rotate nodes to distribute the load
-        if self.round_robin:
-            self.next_node()
-
         body = HttpClient.json_rpc_body(name, *args, api=api)
         response = None
         try:


### PR DESCRIPTION
* Raise exceptions by default (force users to deal with it)
* Reduce timeout and failure tolerance defaults
* Remove linear backoff sleep on retries
* Log on node switch
* Remove round_robin option
* Always failover on non-200 code
* Raise SteemdBadResponse on persistent non-200 responses
* Allow to set max_failovers on init

**Warning:** These changes are altering http_client's behavior, and will likely break users code. Thorough production testing required before merging.